### PR TITLE
Fixed fetching the list of folders

### DIFF
--- a/examples/SharePoint/Folders/ReadFiles.php
+++ b/examples/SharePoint/Folders/ReadFiles.php
@@ -23,7 +23,7 @@ function forEachFile(Folder $parentFolder, $recursive, callable  $action, $level
 
     if ($recursive) {
         /** @var Folder $folder */
-        foreach ($parentFolder->getFolders() as $folder) {
+        foreach ($parentFolder->getFolders()->get()->executeQuery() as $folder) {
             forEachFile($folder, $recursive, $action, $level++);
         }
     }


### PR DESCRIPTION
Hi, I guess that ``foreach ($parentFolder->getFolders() as $folder) { ... }`` alone did not return the folders as array, so the recursion could not work as intended.

Thanks for a great library :)